### PR TITLE
adding 'synonym' bird names to the correct.other_names list

### DIFF
--- a/birdle/scripts/main.js
+++ b/birdle/scripts/main.js
@@ -87,6 +87,22 @@ function BuildQuestion(level, category) {
         var correct = selected[0];
         usedBirds.push(correct);
     }
+    const synonyms = {
+        'nz': 'new zealand',
+    };
+    let namesToAdd = [];
+    correct.other_names.forEach(name => { // If it contains NZ XXX, also add New Zealand XXX to accepted names.
+        name = name.toLowerCase();
+        for (const [shortForm, longForm] of Object.entries(synonyms)) {
+            if (name.includes(shortForm))
+                namesToAdd.push(name.replace(shortForm, longForm));
+            if (name.includes(longForm))
+                namesToAdd.push(name.replace(longForm, shortForm));
+        }
+    })
+    correct.other_names.push.apply(correct.other_names, namesToAdd);
+    correct.other_names = [...new Set(correct.other_names)]; // Removing duplicates
+
     return [question, correct, selected]
 }
 


### PR DESCRIPTION
If you submit 'NZ Pigeon' and the answer is 'New Zealand Pigeon', you get the question wrong.
This fixes that by adding synonyms to the correct.other_names array.