### PR TITLE
Trim entered text before string comparison.

### DIFF
--- a/scripts/questions.js
+++ b/scripts/questions.js
@@ -237,7 +237,7 @@ function checkPickedPicture() {
 function checkEnteredName() {
     const entered = document.getElementById("answer box").value;
     if (entered) {
-        var name = entered.toLowerCase();
+        var name = entered.trim().toLowerCase();
         var got_it_right = correct.other_names.includes(name)
     }
     else {
@@ -250,7 +250,7 @@ function checkEnteredName() {
 function checkEnteredMaoriName() {
     const entered = document.getElementById("answer box").value;
     if (entered) {
-        var name = entered.toLowerCase();
+        var name = entered.trim().toLowerCase();
         var got_it_right = correct.maori_name == entered.toLowerCase()
     }
     else {


### PR DESCRIPTION
This fixes an issue where an answer is rated as wrong if it has whitespace on either end.
This happens when entering words on a mobile using auto-complete.