### PR TITLE
Allow kawaupaka as one word

### DIFF
--- a/birdle/scripts/data.js
+++ b/birdle/scripts/data.js
@@ -16218,6 +16218,7 @@ data = [
             "little pied shag",
             "little cormorant",
             "kawau paka",
+            "kawaupaka",
             "little pied cormorant",
             "little shag",
             "little shag",


### PR DESCRIPTION
Writing kawaupaka as one word seems to be common/standard:

https://nzbirdsonline.org.nz/species/little-shag
https://www.inaturalist.org/taxa/508249-Microcarbo-melanoleucos-brevirostris